### PR TITLE
add linux kernel 4.19-lts for AS7316-26xb

### DIFF
--- a/packages/platforms/accton/x86-64/as7316-26xb/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as7316-26xb/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7316-26xb ARCH=amd64 KERNELS="onl-kernel-4.14-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7316-26xb ARCH=amd64 KERNELS="onl-kernel-4.19-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as7316-26xb/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as7316-26xb/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-4.14-lts-x86-64-all:amd64
+KERNELS := onl-kernel-4.19-lts-x86-64-all:amd64
 KMODULES := $(wildcard *.c)
 VENDOR := accton
 BASENAME := x86-64-accton-as7316-26xb

--- a/packages/platforms/accton/x86-64/as7316-26xb/platform-config/r0/src/lib/x86-64-accton-as7316-26xb-r0.yml
+++ b/packages/platforms/accton/x86-64/as7316-26xb/platform-config/r0/src/lib/x86-64-accton-as7316-26xb-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as7316-26xb-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-4-14
+      <<: *kernel-4-19
 
     args: >-
       nopat

--- a/packages/platforms/accton/x86-64/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/arch-vendor-modules.yml ARCH=amd64 VENDOR=accton KERNELS="onl-kernel-4.14-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/arch-vendor-modules.yml ARCH=amd64 VENDOR=accton KERNELS='onl-kernel-5.4-lts-x86-64-all:amd64','onl-kernel-4.14-lts-x86-64-all:amd64','onl-kernel-4.19-lts-x86-64-all:amd64'

--- a/packages/platforms/accton/x86-64/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-5.4-lts-x86-64-all:amd64
+KERNELS := onl-kernel-5.4-lts-x86-64-all:amd64 onl-kernel-4.19-lts-x86-64-all:amd64 onl-kernel-4.14-lts-x86-64-all:amd64
 KMODULES := $(wildcard *.c)
 VENDOR := accton
 BASENAME := common


### PR DESCRIPTION
This PR adds linux kernel 4.19-lts for [AS7316-26xb](https://stordirect.com/shop/switches/10g-switches/edgecore-networks-csr320-as7316-26xb-disaggregated-cell-site-gateway-dcsg/) (a.k.a CSR320/Disaggregated Cell Site Gateway).
This kernel version is used for this platform so that containerized OcNOS works properly.
This implementation is contributed IP Infusion and NTT.