### PR TITLE
ipi-as7946-30xb: IPMI error fix from Edgecore, supporting BMC  v0.2.

### DIFF
--- a/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/x86-64-accton-as7946-30xb-fan.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/x86-64-accton-as7946-30xb-fan.c
@@ -447,7 +447,7 @@ static ssize_t set_fan(struct device *dev, struct device_attribute *da,
 	mutex_lock(&data->update_lock);
 
 	/* Send IPMI write command */
-	data->ipmi_tx_data[0] = (fid % NUM_OF_FAN_MODULE) + 1;
+	data->ipmi_tx_data[0] = (fid % NUM_OF_FAN_MODULE);
 	data->ipmi_tx_data[1] = 0x02;
 	data->ipmi_tx_data[2] = pwm;
 	status = ipmi_send_message(&data->ipmi, IPMI_FAN_WRITE_CMD,

--- a/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/x86-64-accton-as7946-30xb-psu.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/x86-64-accton-as7946-30xb-psu.c
@@ -397,7 +397,7 @@ static struct as7946_30xb_psu_data *as7946_30xb_psu_update_device(struct device_
 	data->ipmi_resp[pid].status[PSU_VOUT_MODE] = 0xff;
 
 	/* Get status from ipmi */
-	data->ipmi_tx_data[0] = pid + 1; /* PSU ID base id for ipmi start from 1 */
+	data->ipmi_tx_data[0] = pid; /* PSU ID base id for ipmi start from 0 */
 	status = ipmi_send_message(&data->ipmi, IPMI_PSU_READ_CMD,
 								data->ipmi_tx_data, 1,
 								data->ipmi_resp[pid].status,


### PR DESCRIPTION
This changes were provided by Edgecore to fix an issue the following IPMI error messages kept shown.

root@localhost:/sys/devices/platform/as7946_30xb_psu# cat psu2_present
[ 8063.759810] as7946_30xb_psu as7946_30xb_psu: ipmi_send_message_0 err result(203)
[ 8063.771841] as7946_30xb_psu as7946_30xb_psu: ipmi_send_message_1 err result(203)
cat: psu2_present: Input/output error